### PR TITLE
mostly stylistic fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,21 @@ npm install 88nine
 
 ## Playlists
 
-**Fetch** - Get a list of the 100 most recently played songs 
+**Fetch** - Get a list of the 100 most recently played songs
 
 ```javascript
 const playlist = require('88nine').playlist;
 playlist.fetch().then(function(songs) {
   // do something with the songs
-  // Songs is an array of js objects with 
+  // Songs is an array of js objects with
   // the following structure:
 
-  [{ 
+  [{
     playedAt: "2017-10-08T16:58:09.000Z",
     artist: 'Abby Jeanne',
     title: 'Cosmic Beings',
     album: 'Cosmic Beings- Single',
-    composer: '' 
+    composer: ''
   }]
 });
 ```
@@ -46,7 +46,7 @@ playlist.last().then(function(song) {
 const {live} = require('88nine');
 live.local.on('song', function(song) {
   {
-    artist: 'Andrea Day', 
+    artist: 'Andrea Day',
     track: 'Rise Up',
     album: 'Cheers to the Fall',
     playedAt: new Date('2017-10-08T20:02:47.411Z')
@@ -57,7 +57,7 @@ live.local.on('song', function(song) {
 const {live} = require('88nine');
 live.all.on('song', function(song) {
   {
-    artist: 'Andrea Day', 
+    artist: 'Andrea Day',
     track: 'Rise Up',
     album: 'Cheers to the Fall',
     playedAt: new Date('2017-10-08T20:02:47.411Z')

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Library for interacting with 88nine Radio Milwaukee",
   "main": "src/index.js",
   "scripts": {
-    "test": "node_modules/mocha/bin/mocha"
+    "test": "standard && mocha"
   },
   "author": "Nick Gartmann <nick@rokkincat.com>",
   "bugs": {
@@ -23,6 +23,7 @@
   },
   "devDependencies": {
     "mocha": "^4.0.1",
-    "rewire": "^2.5.2"
+    "rewire": "^2.5.2",
+    "standard": "^11.0.1"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,2 +1,2 @@
-exports.playlist = require('./playlist');
-exports.live = require('./live');
+exports.playlist = require('./playlist')
+exports.live = require('./live')

--- a/src/live.js
+++ b/src/live.js
@@ -1,92 +1,91 @@
-var icy = require('icy');
-var EventEmitter = require('events');
-var devnull = require('dev-null');
-var musicbrainz = require('./musicbrainz');
+var icy = require('icy')
+var EventEmitter = require('events')
+var devnull = require('dev-null')
+var musicbrainz = require('./musicbrainz')
 
 module.exports = {
-  "local": new EventEmitter(),
-  "all": new EventEmitter()
+  'local': new EventEmitter(),
+  'all': new EventEmitter()
 }
 
 var PIPES = {}
 const URLS = {
-  "local": "http://wyms.streamguys1.com/414music_aac",
-  "all": "https://wyms.streamguys1.com/live"
+  'local': 'http://wyms.streamguys1.com/414music_aac',
+  'all': 'https://wyms.streamguys1.com/live'
 }
 
-function decodeHTMLEntities(text) {
-    var entities = [
-        ['amp', '&'],
-        ['apos', '\''],
-        ['#x27', '\''],
-        ['#x2F', '/'],
-        ['#39', '\''],
-        ['#47', '/'],
-        ['lt', '<'],
-        ['gt', '>'],
-        ['nbsp', ' '],
-        ['quot', '"']
-    ];
+function decodeHTMLEntities (text) {
+  var entities = [
+    ['amp', '&'],
+    ['apos', '\''],
+    ['#x27', '\''],
+    ['#x2F', '/'],
+    ['#39', '\''],
+    ['#47', '/'],
+    ['lt', '<'],
+    ['gt', '>'],
+    ['nbsp', ' '],
+    ['quot', '"']
+  ]
 
-    for (var i = 0, max = entities.length; i < max; ++i) 
-        text = text.replace(new RegExp('&'+entities[i][0]+';', 'g'), entities[i][1]);
+  for (var i = 0, max = entities.length; i < max; ++i) {
+    text = text.replace(new RegExp('&' + entities[i][0] + ';', 'g'), entities[i][1])
+  }
 
-    return text;
+  return text
 }
 
-
-function parseMetadata(metadata) {
-  var regex = /StreamTitle\='(.+?) - (.+?)';/;
-  var matches = metadata.match(regex);
-  if(matches) {
+function parseMetadata (metadata) {
+  var regex = /StreamTitle\='(.+?) - (.+?)';/
+  var matches = metadata.match(regex)
+  if (matches) {
     return {
       artist: decodeHTMLEntities(matches[1]),
       track: decodeHTMLEntities(matches[2])
     }
   } else {
-    return null;
+    return null
   }
 }
 
 Object.keys(module.exports).forEach((key) => {
   module.exports[key].on('newListener', (event) => {
-    if(event !== 'song') return;
-    if(module.exports[key].listenerCount('song') == 0) {
+    if (event !== 'song') return
+    if (module.exports[key].listenerCount('song') == 0) {
       icy.get(URLS[key], (res) => {
-        res.on("metadata", (metadata) => {
-          metadata = parseMetadata(metadata.toString());
-          if(metadata != null && metadata.artist != '414 Music') {
+        res.on('metadata', (metadata) => {
+          metadata = parseMetadata(metadata.toString())
+          if (metadata != null && metadata.artist != '414 Music') {
             musicbrainz.artist(metadata.artist).then((artistObj) => {
               return musicbrainz.track(metadata.track, artistObj).then((track) => {
                 module.exports[key].emit('song', {
-                  "artist": artistObj.name,
-                  "track": track.title,
-                  "album": track.releases[0].title,
-                  "playedAt": new Date()
-                });
+                  'artist': artistObj.name,
+                  'track': track.title,
+                  'album': track.releases[0].title,
+                  'playedAt': new Date()
+                })
               })
             }).catch((e) => {
               module.exports[key].emit('song', {
-                "artist": metadata.artist,
-                "track": metadata.track,
-                "album": null,
-                "playedAt": new Date()
-              });
-            });
+                'artist': metadata.artist,
+                'track': metadata.track,
+                'album': null,
+                'playedAt': new Date()
+              })
+            })
           }
         })
-        res.pipe(devnull());
-        PIPES[key] = res;
+        res.pipe(devnull())
+        PIPES[key] = res
       })
     }
   })
   module.exports[key].on('removeListener', () => {
-    if(module.exports.listenerCount('song') == 1) {
-      if(PIPES[key]) {
-        PIPES[key].unpipe(devnull());
-        PIPES[key] = null;
+    if (module.exports.listenerCount('song') == 1) {
+      if (PIPES[key]) {
+        PIPES[key].unpipe(devnull())
+        PIPES[key] = null
       }
     }
-  });
+  })
 })
-

--- a/src/live.js
+++ b/src/live.js
@@ -51,11 +51,11 @@ function parseMetadata (metadata) {
 Object.keys(module.exports).forEach((key) => {
   module.exports[key].on('newListener', (event) => {
     if (event !== 'song') return
-    if (module.exports[key].listenerCount('song') == 0) {
+    if (module.exports[key].listenerCount('song') === 0) {
       icy.get(URLS[key], (res) => {
         res.on('metadata', (metadata) => {
           metadata = parseMetadata(metadata.toString())
-          if (metadata != null && metadata.artist != '414 Music') {
+          if (metadata != null && metadata.artist !== '414 Music') {
             musicbrainz.artist(metadata.artist).then((artistObj) => {
               return musicbrainz.track(metadata.track, artistObj).then((track) => {
                 module.exports[key].emit('song', {
@@ -81,7 +81,7 @@ Object.keys(module.exports).forEach((key) => {
     }
   })
   module.exports[key].on('removeListener', () => {
-    if (module.exports.listenerCount('song') == 1) {
+    if (module.exports.listenerCount('song') === 1) {
       if (PIPES[key]) {
         PIPES[key].unpipe(devnull())
         PIPES[key] = null

--- a/src/live.js
+++ b/src/live.js
@@ -36,7 +36,7 @@ function decodeHTMLEntities (text) {
 }
 
 function parseMetadata (metadata) {
-  var regex = /StreamTitle\='(.+?) - (.+?)';/
+  var regex = /StreamTitle='(.+?) - (.+?)';/
   var matches = metadata.match(regex)
   if (matches) {
     return {

--- a/src/musicbrainz.js
+++ b/src/musicbrainz.js
@@ -11,7 +11,7 @@ exports.artist = (name) => {
       path: `/ws/2/artist?query=artist:${encodeURIComponent(name)}&fmt=json`
     }, (response) => {
       var body = ''
-      response.on('data', (chunk) => body += chunk)
+      response.on('data', (chunk) => { body += chunk })
       response.on('end', () => resolve(JSON.parse(body)))
     })
   }).then((artists) => {
@@ -37,7 +37,7 @@ exports.track = (name, artist) => {
       path: `/ws/2/recording?query="${encodeURIComponent(name)}"%20AND%20arid:${artist.id}&fmt=json`
     }, (response) => {
       var body = ''
-      response.on('data', (chunk) => body += chunk)
+      response.on('data', (chunk) => { body += chunk })
       response.on('end', () => resolve(JSON.parse(body)))
     })
   }).then((json) => {

--- a/src/musicbrainz.js
+++ b/src/musicbrainz.js
@@ -1,27 +1,27 @@
-var http = require('http');
+var http = require('http')
 
 exports.artist = (name) => {
   return new Promise((resolve, reject) => {
     http.get({
-      protocol: "http:",
-      hostname: "musicbrainz.org",
+      protocol: 'http:',
+      hostname: 'musicbrainz.org',
       headers: {
-        "User-Agent": "Application 88nine/0.1.0 (radiomilwaukee.org)"
+        'User-Agent': 'Application 88nine/0.1.0 (radiomilwaukee.org)'
       },
       path: `/ws/2/artist?query=artist:${encodeURIComponent(name)}&fmt=json`
     }, (response) => {
-      var body = "";
+      var body = ''
       response.on('data', (chunk) => body += chunk)
       response.on('end', () => resolve(JSON.parse(body)))
     })
   }).then((artists) => {
-    if(artists.artists.length > 0) {
+    if (artists.artists.length > 0) {
       return {
         id: artists.artists[0].id,
         name: artists.artists[0].name
       }
     } else {
-      return null;
+      return null
     }
   })
 }
@@ -29,18 +29,18 @@ exports.artist = (name) => {
 exports.track = (name, artist) => {
   return new Promise((resolve, reject) => {
     http.get({
-      protocol: "http:",
-      hostname: "musicbrainz.org",
+      protocol: 'http:',
+      hostname: 'musicbrainz.org',
       headers: {
-        "User-Agent": "Application 88nine/0.1.0 (radiomilwaukee.org)"
+        'User-Agent': 'Application 88nine/0.1.0 (radiomilwaukee.org)'
       },
       path: `/ws/2/recording?query="${encodeURIComponent(name)}"%20AND%20arid:${artist.id}&fmt=json`
     }, (response) => {
-      var body = "";
+      var body = ''
       response.on('data', (chunk) => body += chunk)
       response.on('end', () => resolve(JSON.parse(body)))
     })
   }).then((json) => {
     return json.recordings[0]
-  });
+  })
 }

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -1,30 +1,30 @@
-var xml2js = require('xml2js');
-var http = require('https');
-var EventEmitter = require('events');
+var xml2js = require('xml2js')
+var http = require('https')
+var EventEmitter = require('events')
 
-const PLAYLIST_URL = "https://s3.amazonaws.com/radiomilwaukee-playlist/WYMSHIS.XML";
+const PLAYLIST_URL = 'https://s3.amazonaws.com/radiomilwaukee-playlist/WYMSHIS.XML'
 
-function fetchPlaylistXml(url) {
+function fetchPlaylistXml (url) {
   return new Promise((resolve, reject) => {
     http.get(PLAYLIST_URL, (response) => {
-      var body = "";
-      response.on('error', (e) => reject(e));
-      response.on('data', (chunk) => body += chunk);
-      response.on('end', () => resolve(body));
-    });
+      var body = ''
+      response.on('error', (e) => reject(e))
+      response.on('data', (chunk) => body += chunk)
+      response.on('end', () => resolve(body))
+    })
   })
 }
 
-function parsePlaylist(rawXml) {
+function parsePlaylist (rawXml) {
   return new Promise((resolve, reject) => {
     xml2js.parseString(rawXml, (error, json) => {
-      if(error) { return reject(error); }
-      resolve(json.PlayList.Song);
-    });
-  });
+      if (error) { return reject(error) }
+      resolve(json.PlayList.Song)
+    })
+  })
 };
 
-function cleanPlaylist(playlist) {
+function cleanPlaylist (playlist) {
   return playlist.map((song) => {
     return {
       playedAt: new Date(song.AIRTIME[0]),
@@ -33,16 +33,16 @@ function cleanPlaylist(playlist) {
       album: song.Album[0],
       composer: song.Composer[0]
     }
-  });
+  })
 }
 
-/* 
+/*
  * Fetch the entire playlist history
  */
-module.exports.fetch = function() {
+module.exports.fetch = function () {
   return fetchPlaylistXml(PLAYLIST_URL)
     .then(parsePlaylist)
-    .then(cleanPlaylist);
+    .then(cleanPlaylist)
 }
 
 /*
@@ -50,14 +50,13 @@ module.exports.fetch = function() {
  * optional count parameter to fetch the last
  * `N` songs.
  */
-module.exports.last = function(amount) {
-  if(amount === undefined) amount = 1;
+module.exports.last = function (amount) {
+  if (amount === undefined) amount = 1
   return module.exports.fetch().then((list) => {
-    if(amount == 1) {
-      return list[0];
+    if (amount == 1) {
+      return list[0]
     } else {
-      return list.slice(0, amount);
+      return list.slice(0, amount)
     }
-  });
+  })
 }
-

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -3,7 +3,7 @@ var http = require('https')
 
 const PLAYLIST_URL = 'https://s3.amazonaws.com/radiomilwaukee-playlist/WYMSHIS.XML'
 
-function fetchPlaylistXml (url) {
+function fetchPlaylistXml () {
   return new Promise((resolve, reject) => {
     http.get(PLAYLIST_URL, (response) => {
       var body = ''

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -1,6 +1,5 @@
 var xml2js = require('xml2js')
 var http = require('https')
-var EventEmitter = require('events')
 
 const PLAYLIST_URL = 'https://s3.amazonaws.com/radiomilwaukee-playlist/WYMSHIS.XML'
 

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -24,15 +24,13 @@ function parsePlaylist (rawXml) {
 };
 
 function cleanPlaylist (playlist) {
-  return playlist.map((song) => {
-    return {
-      playedAt: new Date(song.AIRTIME[0]),
-      artist: song.Artist[0],
-      title: song.Title[0],
-      album: song.Album[0],
-      composer: song.Composer[0]
-    }
-  })
+  return playlist.map((song) => ({
+    playedAt: new Date(song.AIRTIME[0]),
+    artist: song.Artist[0],
+    title: song.Title[0],
+    album: song.Album[0],
+    composer: song.Composer[0]
+  }))
 }
 
 /*

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -8,7 +8,7 @@ function fetchPlaylistXml (url) {
     http.get(PLAYLIST_URL, (response) => {
       var body = ''
       response.on('error', (e) => reject(e))
-      response.on('data', (chunk) => body += chunk)
+      response.on('data', (chunk) => { body += chunk })
       response.on('end', () => resolve(body))
     })
   })

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -52,7 +52,7 @@ module.exports.fetch = function () {
 module.exports.last = function (amount) {
   if (amount === undefined) amount = 1
   return module.exports.fetch().then((list) => {
-    if (amount == 1) {
+    if (amount === 1) {
       return list[0]
     } else {
       return list.slice(0, amount)

--- a/test/playlist_tests.js
+++ b/test/playlist_tests.js
@@ -20,16 +20,16 @@ describe('Playlist', () => {
     it('has all requied attributes', () => {
       return playlist.fetch().then((playlist) => {
         var song = playlist[0]
-        assert(Object.keys(song).indexOf('playedAt') != -1)
+        assert('playedAt' in song)
 
-        assert(Object.keys(song).indexOf('artist') != -1)
-        assert(song.artist == 'Curtis Harding')
+        assert('artist' in song)
+        assert(song.artist === 'Curtis Harding')
 
-        assert(Object.keys(song).indexOf('title') != -1)
-        assert(song.title == 'On and On')
+        assert('title' in song)
+        assert(song.title === 'On and On')
 
-        assert(Object.keys(song).indexOf('album') != -1)
-        assert(song.album == 'Single - On and On')
+        assert('album' in song)
+        assert(song.album === 'Single - On and On')
       })
     })
   })
@@ -37,15 +37,15 @@ describe('Playlist', () => {
   describe('#last()', () => {
     it('Fetches the last song played', () => {
       return playlist.last().then((song) => {
-        assert(song.title == 'On and On')
+        assert(song.title === 'On and On')
       })
     })
 
     it('Fetches the last two songs played', () => {
       return playlist.last(2).then((songs) => {
-        assert(songs.length == 2)
-        assert(songs[0].title == 'On and On')
-        assert(songs[1].title == 'Zonin')
+        assert(songs.length === 2)
+        assert(songs[0].title === 'On and On')
+        assert(songs[1].title === 'Zonin')
       })
     })
   })

--- a/test/playlist_tests.js
+++ b/test/playlist_tests.js
@@ -1,5 +1,6 @@
 var assert = require('assert')
 var rewire = require('rewire')
+const {describe, it} = require('mocha')
 
 var playlist = rewire('../src/playlist')
 playlist.__set__('fetchPlaylistXml', function () {

--- a/test/playlist_tests.js
+++ b/test/playlist_tests.js
@@ -1,58 +1,52 @@
-var assert = require('assert');
-var rewire = require('rewire');
+var assert = require('assert')
+var rewire = require('rewire')
 
-var playlist = rewire('../src/playlist');
-playlist.__set__('fetchPlaylistXml', function() {
-  var fs = require('fs');
+var playlist = rewire('../src/playlist')
+playlist.__set__('fetchPlaylistXml', function () {
+  var fs = require('fs')
   return new Promise((resolve, reject) => {
-    resolve(fs.readFileSync('./test/data/playlist.xml').toString());
-  });
+    resolve(fs.readFileSync('./test/data/playlist.xml').toString())
+  })
 })
 
-
 describe('Playlist', () => {
-
   describe('#fetch()', () => {
     it('is the correct length', () => {
       return playlist.fetch().then((playlist) => {
-        assert.equal(100, playlist.length);
-      });
-    });
+        assert.equal(100, playlist.length)
+      })
+    })
 
     it('has all requied attributes', () => {
       return playlist.fetch().then((playlist) => {
-        var song = playlist[0];
-        assert(Object.keys(song).indexOf('playedAt') != -1);
+        var song = playlist[0]
+        assert(Object.keys(song).indexOf('playedAt') != -1)
 
-        assert(Object.keys(song).indexOf('artist') != -1);
-        assert(song.artist == 'Curtis Harding');
+        assert(Object.keys(song).indexOf('artist') != -1)
+        assert(song.artist == 'Curtis Harding')
 
-        assert(Object.keys(song).indexOf('title') != -1);
-        assert(song.title == 'On and On');
+        assert(Object.keys(song).indexOf('title') != -1)
+        assert(song.title == 'On and On')
 
-        assert(Object.keys(song).indexOf('album') != -1);
-        assert(song.album == 'Single - On and On');
-      });
-    });
-
+        assert(Object.keys(song).indexOf('album') != -1)
+        assert(song.album == 'Single - On and On')
+      })
+    })
   })
 
   describe('#last()', () => {
     it('Fetches the last song played', () => {
       return playlist.last().then((song) => {
-        assert(song.title == 'On and On');
-      });
+        assert(song.title == 'On and On')
+      })
     })
 
     it('Fetches the last two songs played', () => {
       return playlist.last(2).then((songs) => {
-        assert(songs.length == 2);
-        assert(songs[0].title == 'On and On');
-        assert(songs[1].title == 'Zonin');
+        assert(songs.length == 2)
+        assert(songs[0].title == 'On and On')
+        assert(songs[1].title == 'Zonin')
       })
-    });
-  });
-
-
-});
-
+    })
+  })
+})


### PR DESCRIPTION
- ran `standard --fix` and added that to the test script (makes the style more consistent and removes some weird indentation)
- changed some operators to use strict equality checking. this is faster, though probably by an imperceptible amount, and is more likely to behave how you'd expect.
- removed an unused import
- stripped some trailing whitespace

Not much of real importance here.

It might be worthwhile to use [fetch](https://www.npmjs.com/package/node-fetch), since you're wrapping all HTTP requests in a promise anyway, but I haven't tried that out yet.