### PR TITLE
Add a CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ npm install --save 88nine
 
 ## How do I use it?
 
+### As a Node.js Module
+
 ```js
 const {PlaylistStream} = require('88nine')
 
@@ -29,6 +31,33 @@ stream.on('data', (song) => {
 
 // you can destroy it when you're done using the stream, if you want
 stream.destroy()
+```
+
+### As a CLI
+
+88nine also includes a simple CLI, which will be available in your shell as `88nine` if the module was installed using `--global`.
+
+```
+$ 88nine --help
+usage: 88nine [-h] [-v] [-n INTERVAL]
+
+Library for interacting with 88nine Radio Milwaukee
+
+Optional arguments:
+  -h, --help            Show this help message and exit.
+  -v, --version         Show program's version number and exit.
+  -n INTERVAL, --interval INTERVAL
+                        Seconds to wait between updates. Defaults to 60
+                        seconds.
+```
+
+When run, it will print out each song that it finds to STDOUT, as they are played on the radio. This will continue running until you kill it. Songs are formatted as [newline-delimited JSON](http://ndjson.org/).
+
+```
+$ 88nine -n 30
+{"album":"Little Neon Limelight","artist":"Houndmouth","duration":202,"playedAt":"2018-06-19T18:00:02.000Z","title":"Say It"}
+{"album":"The Hanged Man","artist":"Ted Leo","duration":199,"playedAt":"2018-06-19T18:03:26.000Z","title":"Can't Go Back"}
+{"album":"Critical Equation","artist":"Dr. Dog","duration":207,"playedAt":"2018-06-19T18:06:45.000Z","title":"Go Out Fighting"}
 ```
 
 ## Incorrect Songs

--- a/bin/index.js
+++ b/bin/index.js
@@ -1,0 +1,30 @@
+#!/usr/bin/env node
+const packageInfo = require('../package')
+const {ArgumentParser} = require('argparse')
+const JSONStream = require('JSONStream')
+const PlaylistStream = require('../src/playlist-stream')
+
+const argparser = new ArgumentParser({
+  version: packageInfo.version,
+  addHelp: true,
+  description: packageInfo.description
+})
+
+argparser.addArgument(
+  ['-n', '--interval'],
+  {
+    type: 'float',
+    help: 'Seconds to wait between updates. Defaults to 60 seconds.',
+    defaultValue: 60
+  }
+)
+
+const argv = argparser.parseArgs()
+const {interval} = argv
+const stream = new PlaylistStream(interval * 1000)
+
+stream.pipe(
+  JSONStream.stringify('', '\n', '')
+).pipe(
+  process.stdout
+)

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "88nine",
   "version": "0.2.0",
   "description": "Library for interacting with 88nine Radio Milwaukee",
+  "bin": {
+    "88nine": "./bin/index.js"
+  },
   "main": "src",
   "scripts": {
     "test": "standard && mocha"
@@ -17,6 +20,8 @@
   },
   "license": "ISC",
   "dependencies": {
+    "JSONStream": "^1.3.3",
+    "argparse": "^1.0.10",
     "lodash.sortby": "^4.7.0",
     "node-fetch": "^2.1.2",
     "readable-stream": "^2.3.6",


### PR DESCRIPTION
I made this while I was testing - do you want to add it to the package? The interface looks like this:

```bash
$ 88nine --help
usage: 88nine [-h] [-v] [-n INTERVAL]

Library for interacting with 88nine Radio Milwaukee

Optional arguments:
  -h, --help            Show this help message and exit.
  -v, --version         Show program's version number and exit.
  -n INTERVAL, --interval INTERVAL
                        Seconds to wait between updates. Defaults to 60 
                        seconds.
```

and `--version` just pulls from the `package.json`:

```bash
$ 88nine --version
0.2.0
```

When running, it prints out song plays as newline-delimited JSON:
```
$ 88nine -n 5
{"album":"Stay Gold","artist":"First Aid Kit","duration":215,"playedAt":"2018-06-18T15:33:44.000Z","title":"My Silver Lining"}
{"album":"Spectator Sports","artist":"Midnight Reruns","duration":196,"playedAt":"2018-06-18T15:37:20.000Z","title":"Scorpion"}
{"album":"Invasion of Privacy","artist":"Cardi B","duration":264,"playedAt":"2018-06-18T15:41:43.000Z","title":"Best Life"}
```

However, it adds 2 extra deps. If you want to include it, I'll write something to add to the README.