### PR TITLE
Retry requests that fail

### DIFF
--- a/src/playlist-stream.js
+++ b/src/playlist-stream.js
@@ -53,7 +53,9 @@ class PlaylistStream extends Readable {
         this.push.bind(this)
       )
       this._mostRecentPlayedAt = songs[totalNewSongs - 1].playedAt
-    })
+    }).catch((error) =>
+      this.destroy(error)
+    )
   }
 
   _schedulePoll (delay = this._minPollingInterval) {

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -1,10 +1,10 @@
 const xml2js = require('xml2js')
-const http = require('node-fetch')
+const fetch = require('node-fetch')
 
 const PLAYLIST_URL = 'https://s3.amazonaws.com/radiomilwaukee-playlist/WYMSHIS.XML'
 
 let fetchPlaylistXml = () => (
-  http(PLAYLIST_URL).then(
+  fetch(PLAYLIST_URL).then(
     res => res.text()
   )
 )

--- a/src/playlist.js
+++ b/src/playlist.js
@@ -3,10 +3,45 @@ const fetch = require('node-fetch')
 
 const PLAYLIST_URL = 'https://s3.amazonaws.com/radiomilwaukee-playlist/WYMSHIS.XML'
 
-let fetchPlaylistXml = () => (
+/**
+ * @param {int} time Duration of delay
+ * @return {Promise} A promise that returns after a fixed amount of time.
+ */
+const delay = (time) => (
+  new Promise((resolve) => setTimeout(resolve, time))
+)
+
+/**
+ * Check for a non-200 class status code and throw an error if it's detected.
+ * @param {Object} response Fetch response to check
+ * @return {Object} The unchanged response
+ */
+const checkStatus = (res) => {
+  if (res.status >= 200 && res.status < 300) {
+    return res
+  } else {
+    const error = new Error(`Got error ${res.status} (${res.statusText}) when fetching playlist.`)
+    error.response = res
+    throw error
+  }
+}
+
+const fetchPlaylistXml = (retryTime = 1000) => (
   fetch(PLAYLIST_URL).then(
-    res => res.text()
-  )
+    checkStatus
+  ).catch((error) => {
+    let {response} = error
+    if (retryTime > 60000 ||
+       (response != null && (response.status === 404 || response.status === 403))) {
+      // rethrow if we've retried too many times, or if we get a 404.
+      // AWS S3 turns 404s into 403s, so don't retry that either.
+      throw error
+    }
+    return delay(retryTime).then(
+      // grow the delay between retries linearly
+      fetchPlaylistXml.bind(this, retryTime + 1000)
+    )
+  })
 )
 
 function parsePlaylist (rawXml) {
@@ -42,7 +77,8 @@ function cleanPlaylist (playlist) {
  * Fetch the entire playlist history
  */
 module.exports.fetch = function () {
-  return fetchPlaylistXml(PLAYLIST_URL)
+  return fetchPlaylistXml()
+    .then(res => res.text())
     .then(parsePlaylist)
     .then(cleanPlaylist)
 }


### PR DESCRIPTION
Retry any failure that isn't a 404, and have a delay between retries that grows by 1 second for each retry. Also, destroy the stream if an HTTP request fails (after the retry logic has already been used).